### PR TITLE
Fix Google sign-in: replace GetGoogleIdOption with GetSignInWithGoogleOption

### DIFF
--- a/auth/presentation/src/main/java/com/example/presentation/sign_in/SignInScreen.kt
+++ b/auth/presentation/src/main/java/com/example/presentation/sign_in/SignInScreen.kt
@@ -49,8 +49,8 @@ import com.example.allinone.core.presentation.R
 import com.example.presentation.components.AuthTextField
 import com.example.presentation.components.SignInScreenDecoration
 import com.example.presentation.components.SocialIconButton
-import com.example.presentation.sign_up.RegistrationFormEvent
 import com.example.presentation.helper.toastMessage
+import com.example.presentation.sign_up.RegistrationFormEvent
 
 @Composable
 fun SignInScreenRoot(

--- a/auth/presentation/src/main/java/com/example/presentation/sign_in/SignInViewModel.kt
+++ b/auth/presentation/src/main/java/com/example/presentation/sign_in/SignInViewModel.kt
@@ -4,13 +4,16 @@ import android.content.Context
 import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.allinone.core.presentation.R
 import com.example.domain.model.SignInResult
 import com.example.domain.repository.GoogleAuthUiClientRepo
 import com.example.presentation.sign_up.RegistrationFormEvent
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +21,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 @HiltViewModel
 class SignInViewModel @Inject constructor(
@@ -93,27 +97,24 @@ class SignInViewModel @Inject constructor(
         }
     }
 
-    // ---------------- GOOGLE SIGN IN (your existing code) ----------------
+    // ---------------- GOOGLE SIGN IN ----------------
     fun signIn(context: Context) {
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
 
             val result = try {
                 val credentialManager = CredentialManager.create(context)
-
-                val googleIdOption = GetGoogleIdOption.Builder()
-                    .setFilterByAuthorizedAccounts(false)
-                    .setServerClientId(context.getString(R.string.web_client_id))
-                    .setAutoSelectEnabled(false)
-                    .build()
+                val signInOption = GetSignInWithGoogleOption.Builder(
+                    serverClientId = context.getString(R.string.web_client_id),
+                ).build()
 
                 val request = GetCredentialRequest.Builder()
-                    .addCredentialOption(googleIdOption)
+                    .addCredentialOption(signInOption)
                     .build()
 
                 val credentialResponse = credentialManager.getCredential(
                     request = request,
-                    context = context
+                    context = context,
                 )
 
                 when (val credential = credentialResponse.credential) {
@@ -127,7 +128,7 @@ class SignInViewModel @Inject constructor(
 
                             SignInResult(
                                 data = firebaseResult.data,
-                                errorMessage = firebaseResult.errorMessage
+                                errorMessage = firebaseResult.errorMessage,
                             )
                         } else {
                             SignInResult(null, "Unexpected credential type")
@@ -136,8 +137,14 @@ class SignInViewModel @Inject constructor(
 
                     else -> SignInResult(null, "Unexpected credential")
                 }
-            } catch (e: Exception) {
-                SignInResult(null, e.message)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: GetCredentialCancellationException) {
+                SignInResult(null, null)
+            } catch (e: NoCredentialException) {
+                SignInResult(null, "No Google account found on this device. Add one in Settings.")
+            } catch (e: GetCredentialException) {
+                SignInResult(null, "Google sign-in unavailable. Please try again.")
             }
 
             _state.update { it.copy(isLoading = false) }


### PR DESCRIPTION
## Summary
- Fixes the `16: [28433] Cannot find a matching credential` error that surfaced when tapping the Google sign-in button with no filtered/authorized credential cached on the device.
- `GetGoogleIdOption` is the passive/silent flow — when no credential matches, the underlying One Tap call fails. Since our UI is a user-tapped button, `GetSignInWithGoogleOption` is the correct option; it always shows the account-picker UI.
- Exception handling split so `GetCredentialCancellationException` (user dismissed the sheet) no longer surfaces as an error toast, and `NoCredentialException` / other `GetCredentialException` show readable messages.
- Removed the `Log.d` that was added while diagnosing.

## Test plan
- [ ] Fresh install, no prior Google sign-in: tap "Sign in with Google" → account picker appears, sign-in completes
- [ ] Tap Google button, dismiss the sheet → no error toast
- [ ] On a device/emulator with no Google account added → toast reads "No Google account found on this device. Add one in Settings."

🤖 Generated with [Claude Code](https://claude.com/claude-code)